### PR TITLE
Update settings of favonia/cloudflare-ddns

### DIFF
--- a/docker/ansible/templates/compose-modules/cloudflare.yml
+++ b/docker/ansible/templates/compose-modules/cloudflare.yml
@@ -3,9 +3,7 @@ services:
     container_name: cloudflare-ddns
     image: favonia/cloudflare-ddns:1.13.1@sha256:04ecf598596860f029aa7c87ba6d1dcad19494074e43ceb848cf2251eba5e379
     restart: always
-    cap_add:
-      - SETUID
-      - SETGID
+    user: "${PUID}:${PGID}"
     cap_drop:
       - all
     read_only: true
@@ -13,8 +11,6 @@ services:
       - no-new-privileges=true
     mem_limit: 1024m
     environment:
-      - PUID=${PUID}
-      - PGID=${PGID}
       - TZ=${TZ}
       - IP6_PROVIDER=none # Disable IPv6
       - CF_API_TOKEN=$CLOUDFLARE_API_TOKEN


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.